### PR TITLE
feat: add passing `ENVIRONMENT` build arg to kaniko build

### DIFF
--- a/tekton-pipelines/base/tasks/kaniko-task.yaml
+++ b/tekton-pipelines/base/tasks/kaniko-task.yaml
@@ -65,7 +65,7 @@ spec:
       args:
         - --dockerfile=$(resources.inputs.app.path)/$(params.docker_file)
         - --context=$(resources.inputs.app.path)/$(params.docker_context)
-        - --build-arg=ENVIRONMENT=$(ENVIRONMENT)
+        - --build-arg=ENVIRONMENT=$(params.environment)
         - --destination=$(resources.outputs.image.url)
         # - --verbosity=debug
 

--- a/tekton-pipelines/base/tasks/kaniko-task.yaml
+++ b/tekton-pipelines/base/tasks/kaniko-task.yaml
@@ -65,6 +65,7 @@ spec:
       args:
         - --dockerfile=$(resources.inputs.app.path)/$(params.docker_file)
         - --context=$(resources.inputs.app.path)/$(params.docker_context)
+        - --build-arg=ENVIRONMENT=$(ENVIRONMENT)
         - --destination=$(resources.outputs.image.url)
         # - --verbosity=debug
 


### PR DESCRIPTION
Pass ENVIRONMENT build-arg to kaniko executor, so during python projects builds dependencies would be installed from correct env file (which is taken from build params)